### PR TITLE
Replace non-English phrases/examples with English

### DIFF
--- a/.ai/src/skills/agentsync/references/writing-skills.md
+++ b/.ai/src/skills/agentsync/references/writing-skills.md
@@ -61,7 +61,7 @@ The description is the only thing the agent sees during discovery. Vague = invis
 
 - **Imperative phrasing.** "Use this skill when…" beats "This skill does…". The agent is deciding whether to act.
 - **Focus on user intent, not internal mechanics.** Describe what the user is trying to achieve, not the steps the skill takes.
-- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'почему падает'").
+- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'why is it failing'").
 - **Pack relevant keywords** the user might say or type, including alternate phrasings.
 - **Concise but full.** A few sentences usually beats one. Stay under 1024 chars.
 

--- a/.ai/src/skills/commit/SKILL.md
+++ b/.ai/src/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "сохрани изменения").
+description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "save the changes").
 ---
 
 # Commit

--- a/.ai/src/skills/debug/SKILL.md
+++ b/.ai/src/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "почему падает", "не работает X").
+description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "why is it failing", "X doesn't work").
 ---
 
 # Debug

--- a/.ai/src/skills/fix-issue/SKILL.md
+++ b/.ai/src/skills/fix-issue/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   resolve, or tackle a GitHub issue (by number or URL), debug a reported bug
   from the tracker, or work through an issue end-to-end — including phrasings
   like "fix #42", "tackle issue 17", "resolve this GH issue",
-  "почини issue #N", or "разберись с багом из тикета".
+  "figure out the bug from the ticket".
 ---
 
 # Fix Issue

--- a/.ai/src/skills/humanizer/SKILL.md
+++ b/.ai/src/skills/humanizer/SKILL.md
@@ -118,7 +118,7 @@ Before returning the result, read what you wrote with fresh eyes and check four 
 
 First, scan for forbidden marks. Any em dashes, en dashes, hyphens used as pauses, semicolons, framing colons that slipped through, fix them now. Any bold mid-paragraph, kill it.
 
-Second, scan for the banned vocabulary list. The longer the piece, the more likely a "delve" or "utilize" or "данный" snuck back in. Replace it.
+Second, scan for the banned vocabulary list. The longer the piece, the more likely a "delve" or "utilize" or "aforementioned" snuck back in. Replace it.
 
 Third, find any sentence that still sounds templated, promotional, or structurally identical to a nearby sentence. Rewrite those.
 

--- a/.ai/src/skills/refactor/SKILL.md
+++ b/.ai/src/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "приведи в порядок", "это можно сделать чище").
+description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "clean it up", "this could be done cleaner").
 ---
 
 # Refactor

--- a/.ai/src/skills/release/SKILL.md
+++ b/.ai/src/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: Bump the AgentSync version, write a CHANGELOG entry summarising changes since the last tag, and prepare a clean release commit. Use this skill when the user asks to release, ship, cut a version, bump major/minor/patch, tag, or prepare a new version — including phrasings like "let's ship 0.12", "поднять версию", "сделай релиз", or when asked to update CHANGELOG.md after a stretch of work.
+description: Bump the AgentSync version, write a CHANGELOG entry summarising changes since the last tag, and prepare a clean release commit. Use this skill when the user asks to release, ship, cut a version, bump major/minor/patch, tag, or prepare a new version — including phrasings like "let's ship 0.12", "bump the version", "make a release", or when asked to update CHANGELOG.md after a stretch of work.
 ---
 
 # Release

--- a/.ai/src/skills/review/SKILL.md
+++ b/.ai/src/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK", "глянь, всё ли нормально", "посмотри на это").
+description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK").
 ---
 
 # Code Review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.33.3
+
+### Changed
+
+- **Shipped skill templates use English-only discovery examples.** Russian trigger phrases in bundled skill descriptions and writing guidance are replaced with English equivalents or removed when redundant; Existing projects pick up these changes via `agentsync refresh` or `init`.
+
 ## 0.33.2
 
 ### Added

--- a/example/.ai/src/skills/agentsync/references/writing-skills.md
+++ b/example/.ai/src/skills/agentsync/references/writing-skills.md
@@ -61,7 +61,7 @@ The description is the only thing the agent sees during discovery. Vague = invis
 
 - **Imperative phrasing.** "Use this skill when…" beats "This skill does…". The agent is deciding whether to act.
 - **Focus on user intent, not internal mechanics.** Describe what the user is trying to achieve, not the steps the skill takes.
-- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'почему падает'").
+- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'why is it failing'").
 - **Pack relevant keywords** the user might say or type, including alternate phrasings.
 - **Concise but full.** A few sentences usually beats one. Stay under 1024 chars.
 

--- a/example/.ai/src/skills/commit/SKILL.md
+++ b/example/.ai/src/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "сохрани изменения").
+description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "save the changes").
 ---
 
 # Commit

--- a/example/.ai/src/skills/debug/SKILL.md
+++ b/example/.ai/src/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "почему падает", "не работает X").
+description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "why is it failing", "X doesn't work").
 ---
 
 # Debug

--- a/example/.ai/src/skills/refactor/SKILL.md
+++ b/example/.ai/src/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "приведи в порядок", "это можно сделать чище").
+description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "clean it up", "this could be done cleaner").
 ---
 
 # Refactor

--- a/example/.ai/src/skills/review/SKILL.md
+++ b/example/.ai/src/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK", "глянь, всё ли нормально", "посмотри на это").
+description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK").
 ---
 
 # Code Review

--- a/lib/prompts/generate.md
+++ b/lib/prompts/generate.md
@@ -119,7 +119,7 @@ description: >-
 
 **Critical for skills:**
 
-- The `description` is a TRIGGER. Discovery is the only thing the agent sees at startup, so vague = invisible. Make it imperative ("Use this skill when…"), pushy (list cases where the user doesn't name the domain — "even when phrased as 'this is broken' or 'почему падает'"), and keyword-rich. Stay under 1024 chars.
+- The `description` is a TRIGGER. Discovery is the only thing the agent sees at startup, so vague = invisible. Make it imperative ("Use this skill when…"), pushy (list cases where the user doesn't name the domain — "even when phrased as 'this is broken' or 'why is it failing'"), and keyword-rich. Stay under 1024 chars.
 - `Gotchas` is the single highest-leverage section — concrete corrections to wrong assumptions ("the `users` table uses soft deletes; queries must include `WHERE deleted_at IS NULL`"), not generic advice. Include 2-3 based on what could actually go wrong in this project; update it every time the agent makes a mistake using the skill.
 - **Aim for 50–150 lines** when the workflow is simple. Cap at 500 lines / 5000 tokens hard. Beyond that, move detail to `references/<topic>.md` and load it with an explicit trigger ("read `references/X.md` when Y") — not a vague "see references/".
 - Apply the Universal principles above (add-what-agent-lacks, procedures-over-declarations, defaults-not-menus, match-specificity-to-fragility) — they matter most for skills.

--- a/lib/templates/skills/agentsync/references/writing-skills.md
+++ b/lib/templates/skills/agentsync/references/writing-skills.md
@@ -61,7 +61,7 @@ The description is the only thing the agent sees during discovery. Vague = invis
 
 - **Imperative phrasing.** "Use this skill when…" beats "This skill does…". The agent is deciding whether to act.
 - **Focus on user intent, not internal mechanics.** Describe what the user is trying to achieve, not the steps the skill takes.
-- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'почему падает'").
+- **Be pushy.** Explicitly list contexts where the skill applies, *including ones where the user doesn't name the domain* ("even when phrased as 'this is broken' or 'why is it failing'").
 - **Pack relevant keywords** the user might say or type, including alternate phrasings.
 - **Concise but full.** A few sentences usually beats one. Stay under 1024 chars.
 

--- a/lib/templates/skills/commit/SKILL.md
+++ b/lib/templates/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "сохрани изменения").
+description: Create a well-structured git commit for staged or unstaged changes — analyze the diff, match the project's existing commit style, write a clear message, and create the commit. Use this skill when the user asks to commit, save changes, check in code, write a commit message, prepare changes for push, or wrap up a piece of work — even when they don't say "commit" explicitly (e.g. "let's save this", "ship it", "save the changes").
 ---
 
 # Commit

--- a/lib/templates/skills/debug/SKILL.md
+++ b/lib/templates/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "почему падает", "не работает X").
+description: Investigate and fix bugs, errors, or unexpected behavior systematically — reproduce, locate, understand the root cause, fix it, and add a regression test. Use this skill when the user reports a failure (test, runtime, build, CI), shares a stack trace or error message, says something doesn't work, asks why something is broken, or asks for a fix that requires diagnosis — even when the word "debug" is not used (e.g. "this is broken", "why is it failing", "X doesn't work").
 ---
 
 # Debug

--- a/lib/templates/skills/humanizer/SKILL.md
+++ b/lib/templates/skills/humanizer/SKILL.md
@@ -118,7 +118,7 @@ Before returning the result, read what you wrote with fresh eyes and check four 
 
 First, scan for forbidden marks. Any em dashes, en dashes, hyphens used as pauses, semicolons, framing colons that slipped through, fix them now. Any bold mid-paragraph, kill it.
 
-Second, scan for the banned vocabulary list. The longer the piece, the more likely a "delve" or "utilize" or "данный" snuck back in. Replace it.
+Second, scan for the banned vocabulary list. The longer the piece, the more likely a "delve" or "utilize" or "aforementioned" snuck back in. Replace it.
 
 Third, find any sentence that still sounds templated, promotional, or structurally identical to a nearby sentence. Rewrite those.
 

--- a/lib/templates/skills/refactor/SKILL.md
+++ b/lib/templates/skills/refactor/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refactor
-description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "приведи в порядок", "это можно сделать чище").
+description: Restructure existing code without changing its behavior — reduce duplication, improve naming, simplify complex logic, extract helpers, split overgrown functions, untangle dependencies. Use this skill when the user asks to refactor, clean up, simplify, DRY out, rename, extract a helper, split a file, or make code "nicer" — including when they describe code-quality concerns without using the word "refactor" (e.g. "this is messy", "clean it up", "this could be done cleaner").
 ---
 
 # Refactor

--- a/lib/templates/skills/review/SKILL.md
+++ b/lib/templates/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK", "глянь, всё ли нормально", "посмотри на это").
+description: Perform a structured code review on a diff, PR, or staged changes — surface correctness, security, error-handling, architecture, testing, and clarity issues with file/line references and severity. Use this skill when the user asks to review code, audit a diff or PR, find bugs in changes before merging, sanity-check work before pushing, or look over an implementation — including when phrased softly ("look over this", "check if this is OK").
 ---
 
 # Code Review


### PR DESCRIPTION
docs(skills): replace non-English trigger examples with English

Skill descriptions and writing guidance used Russian phrases as discovery examples; swap them for English equivalents or drop redundant phrases.

---

Feel free to criticize or push back on this.  I came across several examples of Russian phrases throughout the codebase and I've replaced or removed them.  I removed these manually for my use-case, but it would be more convenient if they were not present in the overall codebase.  Let me know what you think.

## Summary by Sourcery

Standardize bundled skill templates and guidance on English-only trigger examples and phrases.

Enhancements:
- Replace non-English (Russian) trigger phrases in bundled skill descriptions, templates, and prompts with English equivalents or remove them when redundant to keep discovery examples consistent.

Documentation:
- Update writing guidance to use English-only examples for trigger phrases and user phrasings.
- Note in the changelog that shipped skill templates now use English-only discovery examples and how projects pick up the change.