### PR TITLE
fix: shared overlay no longer aborts on missing commands/agents dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.33.4
+
+### Fixed
+
+- **Shared overlay sync no longer aborts when commands or agents dirs are absent.** `_overlay_rewrite_sources` tested optional overlay paths with `[[ ]] && assign`, which returns 1 when a directory is missing and aborted nested workspace sync under `set -e` when `shared.inherit` omitted empty categories. Paths are now guarded with `if/fi` so sync continues.
+
 ## 0.33.3
 
 ### Changed

--- a/lib/helpers/shared.sh
+++ b/lib/helpers/shared.sh
@@ -90,16 +90,28 @@ build_overlay_tree() {
 # Usage: _overlay_rewrite_sources <tmpdir>
 _overlay_rewrite_sources() {
     local tmpdir="$1"
-    # shellcheck disable=SC2034
-    [[ -f "$tmpdir/src/AGENTS.md" ]] && SOURCE_AGENTS="$tmpdir/src/AGENTS.md"
-    # shellcheck disable=SC2034
-    [[ -d "$tmpdir/src/rules" ]]    && SOURCE_RULES="$tmpdir/src/rules"
-    # shellcheck disable=SC2034
-    [[ -d "$tmpdir/src/skills" ]]   && SOURCE_SKILLS="$tmpdir/src/skills"
-    # shellcheck disable=SC2034
-    [[ -d "$tmpdir/src/commands" ]] && SOURCE_COMMANDS="$tmpdir/src/commands"
-    # shellcheck disable=SC2034
-    [[ -d "$tmpdir/src/agents" ]]   && SOURCE_SUBAGENTS="$tmpdir/src/agents"
+    # Use if/fi — plain `[[ ]] && assign` returns 1 when the path is missing, which
+    # aborts sync under set -e (common when shared inherit omits empty categories).
+    if [[ -f "$tmpdir/src/AGENTS.md" ]]; then
+        # shellcheck disable=SC2034
+        SOURCE_AGENTS="$tmpdir/src/AGENTS.md"
+    fi
+    if [[ -d "$tmpdir/src/rules" ]]; then
+        # shellcheck disable=SC2034
+        SOURCE_RULES="$tmpdir/src/rules"
+    fi
+    if [[ -d "$tmpdir/src/skills" ]]; then
+        # shellcheck disable=SC2034
+        SOURCE_SKILLS="$tmpdir/src/skills"
+    fi
+    if [[ -d "$tmpdir/src/commands" ]]; then
+        # shellcheck disable=SC2034
+        SOURCE_COMMANDS="$tmpdir/src/commands"
+    fi
+    if [[ -d "$tmpdir/src/agents" ]]; then
+        # shellcheck disable=SC2034
+        SOURCE_SUBAGENTS="$tmpdir/src/agents"
+    fi
 }
 
 # Read `shared.path` and `shared.inherit` from the project config and

--- a/tests/shared.bats
+++ b/tests/shared.bats
@@ -37,6 +37,51 @@ EOF
     echo "$parent_dir $child_dir"
 }
 
+# Helper: rules-only `--no-templates` scaffold — no commands/, agents/, or AGENTS.md.
+# The shared overlay tmpdir then lacks those paths; _overlay_rewrite_sources must
+# not abort sync under set -e when they are missing.
+_shared_make_sparse_pair() {
+    local parent_dir="$TEST_PROJECT/parent_sparse"
+    local child_dir="$parent_dir/child"
+    local init_flags=(--no-templates --no-detect --content rules --yes)
+
+    mkdir -p "$parent_dir"
+    ( cd "$parent_dir" && AGENTSYNC_HOME="$REPO_ROOT" bash "$AGENTSYNC_BIN" init "${init_flags[@]}" >/dev/null )
+    echo "parent-rule" > "$parent_dir/.ai/src/rules/parent-only.md"
+
+    mkdir -p "$child_dir"
+    ( cd "$child_dir" && AGENTSYNC_HOME="$REPO_ROOT" bash "$AGENTSYNC_BIN" init "${init_flags[@]}" >/dev/null )
+    ( cd "$child_dir" && AGENTSYNC_HOME="$REPO_ROOT" bash "$AGENTSYNC_BIN" enable claude --no-scaffold >/dev/null )
+    echo "child-rule" > "$child_dir/.ai/src/rules/child-only.md"
+
+    for dir in "$parent_dir" "$child_dir"; do
+        [ -d "$dir/.ai/src/rules" ]
+        [ ! -d "$dir/.ai/src/commands" ]
+        [ ! -d "$dir/.ai/src/agents" ]
+        [ ! -f "$dir/.ai/src/AGENTS.md" ]
+    done
+
+    cat >> "$child_dir/.ai/agent_sync.yaml" <<'EOF'
+
+shared:
+  path: "../"
+  inherit: rules
+EOF
+    echo "$parent_dir $child_dir"
+}
+
+@test "shared: sync succeeds when overlay omits commands, agents, and AGENTS.md" {
+    local pair child
+    pair=$(_shared_make_sparse_pair)
+    child="${pair##* }"
+
+    run bash -c "cd '$child' && AGENTSYNC_HOME='$REPO_ROOT' bash '$AGENTSYNC_BIN' sync"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Shared overlay active"* ]]
+    [ -f "$child/.claude/rules/parent-only.md" ]
+    [ -f "$child/.claude/rules/child-only.md" ]
+}
+
 @test "shared: parent rules materialise into child output dirs" {
     local pair child
     pair=$(_shared_make_pair)


### PR DESCRIPTION
fix(sync): shared overlay no longer aborts on missing commands/agents dirs

_overlay_rewrite_sources used [[ ]] && assign; a missing overlay path returns 1 and killed nested workspace sync under set -e when shared inherit omitted empty categories. Use if/fi so optional inherited categories can be absent.

---

Long story short, you might have a nested .ai/ directory with an 'agent_sync.yaml' with explicit rules to inherit repo-wide rules, skills, etc. EX:
```
shared:
  path: "../../../"
  inherit: rules, skills, commands, agents
```

If any of these folders are empty (ex: agents/, commands/, etc.), it causes an error when running commands like `agentsync sync --workspace` (generating ai rules at the top-level and any nested instances).  This fix allows you to keep these inherit rules (for future-proofing), and if such folders are empty they are now skipped instead of hitting errors.

I ran 'bats' against the new test created and it passed for me.

## Summary by Sourcery

Allow shared overlay sync to succeed when optional overlay categories are missing.

Bug Fixes:
- Prevent shared overlay sync from aborting under set -e when commands, agents, or AGENTS.md paths are absent in the inherited overlay.

Documentation:
- Update changelog with a 0.33.4 entry describing the shared overlay sync fix.

Tests:
- Add a sparse shared overlay test ensuring sync succeeds when commands, agents, and AGENTS.md are omitted from the overlay.